### PR TITLE
Organizr: Fix Docker env boolean/string, fix paths for new image

### DIFF
--- a/defaults/adv_settings.yml.default
+++ b/defaults/adv_settings.yml.default
@@ -21,7 +21,7 @@ darkerr:
   enable: no
 organizr:
   direct_domain: no
-  fpm: yes
+  fpm: "yes"
   branch: v2-develop
 nginx:
   direct_domain: no

--- a/defaults/adv_settings.yml.default
+++ b/defaults/adv_settings.yml.default
@@ -22,7 +22,7 @@ darkerr:
 organizr:
   direct_domain: no
   fpm: "yes"
-  branch: v2-develop
+  branch: v2-master
 nginx:
   direct_domain: no
   subdomain: web

--- a/roles/organizr/tasks/main.yml
+++ b/roles/organizr/tasks/main.yml
@@ -69,7 +69,7 @@
     published_ports:
       - "127.0.0.1:7421:80"
     env:
-      fpm: "{{ (organizr.fpm|default(false,true)|string) }}"
+      fpm: "{{ (organizr.fpm|default(false,true)) }}"
       branch: "{{ (organizr.branch|default(false,true)) }}"
       PUID: "{{ uid }}"
       PGID: "{{ gid }}"

--- a/roles/organizr/tasks/main.yml
+++ b/roles/organizr/tasks/main.yml
@@ -69,7 +69,7 @@
     published_ports:
       - "127.0.0.1:7421:80"
     env:
-      fpm: "{{ (organizr.fpm|default(false,true)) }}"
+      fpm: "{{ (organizr.fpm|default(false,true)|string) }}"
       branch: "{{ (organizr.branch|default(false,true)) }}"
       PUID: "{{ uid }}"
       PGID: "{{ gid }}"
@@ -92,77 +92,82 @@
 
 - name: Wait for Organizr.css to be created
   wait_for:
-    path: "/opt/organizr/www/Dashboard/css/themes/Organizr.css"
+    path: "/opt/organizr/www/organizr/css/themes/Organizr.css"
     state: present
 
 - name: Download Gilbn Plex Theme
   get_url:
     url:  "https://raw.githubusercontent.com/gilbN/theme.park/master/CSS/themes/plex/plex-base.css"
-    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    dest: "/opt/organizr/www/organizr/css/themes/"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
     mode: 0664
     force: yes
     validate_certs: no
+    ignore_errors: yes
 
 - name: Download Gilbn AquaMarine Theme
   get_url:
     url:  "https://raw.githubusercontent.com/gilbN/theme.park/master/CSS/themes/plex/aquamarine.css"
-    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    dest: "/opt/organizr/www/organizr/css/themes/"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
     mode: 0664
     force: yes
     validate_certs: no
+    ignore_errors: yes
 
 - name: Download Gilbn Dark Theme
   get_url:
     url:  "https://raw.githubusercontent.com/gilbN/theme.park/master/CSS/themes/plex/dark.css"
-    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    dest: "/opt/organizr/www/organizr/css/themes/"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
     mode: 0664
     force: yes
     validate_certs: no
+    ignore_errors: yes
 
 - name: Download Gilbn Hotline Theme
   get_url:
     url:  "https://github.com/gilbN/theme.park/blob/master/CSS/themes/plex/hotline.css"
-    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    dest: "/opt/organizr/www/organizr/css/themes/"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
     mode: 0664
     force: yes
     validate_certs: no
+    ignore_errors: yes
 
 - name: Download Gilbn Organizr Dark Theme
   get_url:
     url:  "https://github.com/gilbN/theme.park/blob/master/CSS/themes/plex/organizr-dark.css"
-    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    dest: "/opt/organizr/www/organizr/css/themes/"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
     mode: 0664
     force: yes
     validate_certs: no
+    ignore_errors: yes
 
 - name: Download Gilbn Space Grey Theme
   get_url:
     url:  "https://github.com/gilbN/theme.park/blob/master/CSS/themes/plex/space-gray.css"
-    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    dest: "/opt/organizr/www/organizr/css/themes/"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
     mode: 0664
     force: yes
     validate_certs: no
+    ignore_errors: yes
 
 - name: Download Burry Plex Theme
   get_url: 
     url: "https://raw.githubusercontent.com/Burry/organizr-v2-plex-theme/master/css/Plex.css"
-    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    dest: "/opt/organizr/www/organizr/css/themes/"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
     mode: 0664
     force: yes
     validate_certs: no
-    
-  ignore_errors: yes
+    ignore_errors: yes


### PR DESCRIPTION
1) Fixed `fpm:` env in Docker container creation falsely detecting boolean by converting to string
2) Updated css/theme paths for new image paths